### PR TITLE
Set default Night Light settings

### DIFF
--- a/debian/elementary-default-settings.gsettings-override
+++ b/debian/elementary-default-settings.gsettings-override
@@ -125,6 +125,9 @@ scroll-method='two-finger-scrolling'
 [org.gnome.settings-daemon.plugins.background]
 active=false
 
+[org.gnome.settings-daemon.plugins.color]
+night-light-temperature=4500
+
 [org.gnome.settings-daemon.plugins.cursor]
 # Workaround upstream gnome-settings-daemon bug (https://bugzilla.gnome.org/show_bug.cgi?id=694758) as tracked by elementary (https://bugs.launchpad.net/elementaryos/+bug/1248747)
 active=false


### PR DESCRIPTION
We wanna use 4500 as our default, as reflected in https://github.com/elementary/switchboard-plug-display/pull/72 and https://github.com/elementary/wingpanel-indicator-nightlight/pull/8