### PR TITLE
Disable printer discovery notifications

### DIFF
--- a/debian/elementary-default-settings.gsettings-override
+++ b/debian/elementary-default-settings.gsettings-override
@@ -137,6 +137,9 @@ terminal='<Super>t'
 ambient-enabled=false
 idle-dim=false
 
+[org.gnome.settings-daemon.plugins.print-notifications]
+active=false
+
 [org.gnome.settings-daemon.plugins.screensaver-proxy]
 # Allows light-locker to accept DBus
 active=false


### PR DESCRIPTION
Should fix #12 

We should also test if this disables other useful printer notifications or not.