### PR TITLE
Show Date in Panel (wingpanel-datetime)

### DIFF
--- a/debian/elementary-default-settings.gsettings-override
+++ b/debian/elementary-default-settings.gsettings-override
@@ -30,6 +30,7 @@ icon-theme='elementary'
 monospace-font-name='Roboto Mono 10'
 show-unicode-menu=false
 toolbar-style='icons'
+clock-show-date=true
 
 [org.gnome.desktop.peripherals.touchpad]
 natural-scroll=true


### PR DESCRIPTION
The Default settings need to be updated to support new Wingpanel configuration options in elementary/wingpanel-indicator-datetime#53