### PR TITLE
Set clock-show-date to true

### DIFF
--- a/debian/elementary-default-settings.gsettings-override
+++ b/debian/elementary-default-settings.gsettings-override
@@ -25,6 +25,7 @@ exec='io.elementary.terminal'
 xkb-options=['grp:alt_shift_toggle']
 
 [org.gnome.desktop.interface]
+clock-show-date=true
 cursor-theme='elementary'
 document-font-name='Open Sans 10'
 font-name='Open Sans 9'


### PR DESCRIPTION
Make sure we don't change the default appearance with https://github.com/elementary/wingpanel-indicator-datetime/pull/81