### PR TITLE
 Accept only first party cookies for enhanced privacy

### DIFF
--- a/overrides/default-settings.gschema.override
+++ b/overrides/default-settings.gschema.override
@@ -100,7 +100,7 @@ default-search-engine='Google'
 
 [org.gnome.Epiphany.ui]
 expand-tabs-bar=false
-tabs-bar-visibility-policy='always'
+tabs-bar-visibility-policy='no-third-party'
 
 [org.gnome.Epiphany.web]
 cookies-policy='always'

--- a/overrides/default-settings.gschema.override
+++ b/overrides/default-settings.gschema.override
@@ -100,10 +100,10 @@ default-search-engine='Google'
 
 [org.gnome.Epiphany.ui]
 expand-tabs-bar=false
-tabs-bar-visibility-policy='no-third-party'
+tabs-bar-visibility-policy='always'
 
 [org.gnome.Epiphany.web]
-cookies-policy='always'
+cookies-policy='no-third-party'
 do-not-track=false
 enable-adblock=false
 enable-smooth-scrolling=true


### PR DESCRIPTION
Out of the box, Ephemeral and Brave both block third-party cookies to reduce unwanted forms of cross-site tracking via ads. It'd be great for elementary's default browser to ship a privacy enhancing default. Fixes #127.

The same setting has been working well for me in Firefox (my default browser) since over a year, without any noticeable regression. In my limited testing, as far as I can tell, Epiphany is working fine with some popular sites.