### PR TITLE
Add AccountsService interfaces for greeter power settings

### DIFF
--- a/accountsservice/io.elementary.pantheon.AccountsService.xml
+++ b/accountsservice/io.elementary.pantheon.AccountsService.xml
@@ -16,5 +16,21 @@
       <annotation name="org.freedesktop.Accounts.DefaultValue.String" value="24h"/>
     </property>
 
+    <property name="SleepInactiveACTimeout" type="i" access="readwrite">
+      <annotation name="org.freedesktop.Accounts.DefaultValue" value="1200"/>
+    </property>
+
+    <property name="SleepInactiveACType" type="i" access="readwrite">
+      <annotation name="org.freedesktop.Accounts.DefaultValue" value="1"/>
+    </property>
+
+    <property name="SleepInactiveBatteryTimeout" type="i" access="readwrite">
+      <annotation name="org.freedesktop.Accounts.DefaultValue" value="1200"/>
+    </property>
+
+    <property name="SleepInactiveBatteryType" type="i" access="readwrite">
+      <annotation name="org.freedesktop.Accounts.DefaultValue" value="1"/>
+    </property>
+
   </interface>
 </node>


### PR DESCRIPTION
These are the required keys for the power settings plug to be able to set power settings readable by the greeter.