### PR TITLE
Block tracking ads by default

### DIFF
--- a/overrides/default-settings.gschema.override
+++ b/overrides/default-settings.gschema.override
@@ -105,7 +105,7 @@ tabs-bar-visibility-policy='always'
 [org.gnome.Epiphany.web]
 cookies-policy='no-third-party'
 do-not-track=false
-enable-adblock=false
+enable-adblock=true
 enable-smooth-scrolling=true
 
 [org.gnome.mutter]


### PR DESCRIPTION
Out of the box, Firefox, GNOME Epiphany and Brave block tracking ads, for enhanced privacy. Safari is going to join the list with the new WekKit tracking protection spec. It'd be great for elementary's Epiphany to ship a privacy enhancing default that also saves a lot of annoyance while browsing on the web. This PR fixes #126. 

Firefox hasn't shown any functional regression since over a year of enabling the setting there. And in my limited testing, Epiphany is working fine too with some popular sites.