### PR TITLE
Cleanup settings in override

### DIFF
--- a/overrides/default-settings.gschema.override
+++ b/overrides/default-settings.gschema.override
@@ -109,7 +109,6 @@ enable-adblock=false
 enable-smooth-scrolling=true
 
 [org.gnome.mutter]
-auto-maximize=false
 overlay-key='Super_L'
 center-new-windows=true
 workspaces-only-on-primary=true
@@ -136,17 +135,9 @@ active=false
 [org.gnome.settings-daemon.plugins.color]
 night-light-temperature=4500
 
-[org.gnome.settings-daemon.plugins.cursor]
-# Workaround upstream gnome-settings-daemon bug (https://bugzilla.gnome.org/show_bug.cgi?id=694758) as tracked by elementary (https://bugs.launchpad.net/elementaryos/+bug/1248747)
-active=false
-
 [org.gnome.settings-daemon.plugins.media-keys]
 screensaver='<Super>l'
 terminal='<Super>t'
-
-[org.gnome.settings-daemon.plugins.power]
-ambient-enabled=false
-idle-dim=false
 
 [org.gnome.settings-daemon.plugins.screensaver-proxy]
 # Allows light-locker to accept DBus


### PR DESCRIPTION
Breakdown of dropped settings:

- auto-maximize=false
I believe its been discussed in the gala issue tracker
that it's desired for almost fullscreen windows to
be auto maximized. And notoriously I've noticed
this with applications like epiphany, where it's allmost
fullscreen, and it makes the panel look very strange
not being completely opaque and having a gap.
I haven't noticed issues with it being set.

Introduced in de894b7f76fdb0b06523ab8b73a694447036fe72.

- org.gnome-settings-daemon.plugins.cursor
This was introduced to workaround a bug where
cursors would be invisible with g-s-d. The report [0]
was never actually closed, and I haven't noticed any
one's recently. I believe the issue is now gone in recent versions.
( reports mentioned gtk 3.10)

- org.gnome.settings-daemon.plugins.power
- ambient-enabled=false
- idle-dim=false

These are just powersettings that are defaults
in g-s-d that appear to be completely sane.

[0]: https://bugzilla.gnome.org/show_bug.cgi?id=694758

---

I've been using this in NixOS and Soon™ a downstream patch like the rest of the PRs in this repo...