### PR TITLE
Don't Inactivate g-s-d cursor plugin

### DIFF
--- a/overrides/default-settings.gschema.override
+++ b/overrides/default-settings.gschema.override
@@ -136,10 +136,6 @@ active=false
 [org.gnome.settings-daemon.plugins.color]
 night-light-temperature=4500
 
-[org.gnome.settings-daemon.plugins.cursor]
-# Workaround upstream gnome-settings-daemon bug (https://bugzilla.gnome.org/show_bug.cgi?id=694758) as tracked by elementary (https://bugs.launchpad.net/elementaryos/+bug/1248747)
-active=false
-
 [org.gnome.settings-daemon.plugins.media-keys]
 screensaver='<Super>l'
 terminal='<Super>t'


### PR DESCRIPTION
This was introduced to workaround a bug where cursors would be invisible 
with g-s-d. The report [0] was never actually closed, and I haven't noti-
ced any one's recently. I believe the issue is now gone in recent versions.
(reports mentioned gtk 3.10) The was also interfering with cursor-size settings.

Fixes https://github.com/elementary/gala/issues/300

[0]: https://bugzilla.gnome.org/show_bug.cgi?id=694758