### PR TITLE
Enable ambient and idle-dim in g-s-d power

### DIFF
--- a/overrides/default-settings.gschema.override
+++ b/overrides/default-settings.gschema.override
@@ -144,10 +144,6 @@ active=false
 screensaver='<Super>l'
 terminal='<Super>t'
 
-[org.gnome.settings-daemon.plugins.power]
-ambient-enabled=false
-idle-dim=false
-
 [org.gnome.settings-daemon.plugins.screensaver-proxy]
 # Allows light-locker to accept DBus
 active=false


### PR DESCRIPTION
These are just powersettings that are defaults
in g-s-d that appear to be completely sane.