### PR TITLE
Don't set draw-background

### DIFF
--- a/overrides/default-settings.gschema.override
+++ b/overrides/default-settings.gschema.override
@@ -9,7 +9,6 @@ theme='Gtk+'
 triggers=['<Control>space']
 
 [org.gnome.desktop.background]
-draw-background=true
 picture-options='zoom'
 picture-uri='file:///usr/share/backgrounds/elementaryos-default'
 primary-color='#000000'


### PR DESCRIPTION
gsettings-desktop-schemas removed this key a long time ago [0].
It appears ubuntu has reverted this for some reason, though it's
completely ignored and deprecated. Having this in the overrride
should be needless because ubuntu has the setting on by default.

[0]: https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas/commit/a59b45e766a2b3732b3bd2473ee5fbe7607a7f75