### PR TITLE
Make default search engine DuckDuckGo

### DIFF
--- a/overrides/default-settings.gschema.override
+++ b/overrides/default-settings.gschema.override
@@ -94,9 +94,6 @@ theme='elementary'
 titlebar-font='Open Sans Bold 9'
 titlebar-uses-system-font=false
 
-[org.gnome.Epiphany]
-default-search-engine='DuckDuckGo'
-
 [org.gnome.Epiphany.ui]
 expand-tabs-bar=false
 tabs-bar-visibility-policy='always'

--- a/overrides/default-settings.gschema.override
+++ b/overrides/default-settings.gschema.override
@@ -95,7 +95,7 @@ titlebar-font='Open Sans Bold 9'
 titlebar-uses-system-font=false
 
 [org.gnome.Epiphany]
-default-search-engine='Google'
+default-search-engine='DuckDuckGo'
 
 [org.gnome.Epiphany.ui]
 expand-tabs-bar=false


### PR DESCRIPTION
We changed this a long time ago because search results weren't very good. However, I think at this time the results for DuckDuckGo have improved a lot and it would be good to consider this switch again