### PR TITLE
Automatically show & hide the property panel of IBus

### DIFF
--- a/overrides/default-settings.gschema.override
+++ b/overrides/default-settings.gschema.override
@@ -8,6 +8,9 @@ theme='Gtk+'
 [org.freedesktop.ibus.general.hotkey]
 triggers=['<Control>space']
 
+[org.freedesktop.ibus.panel]
+show=1
+
 [org.gnome.desktop.background]
 picture-options='zoom'
 picture-uri='file:///usr/share/backgrounds/elementaryos-default'


### PR DESCRIPTION
Fixes #143

0 = Do not show (default)
1 = Auto hide
2 = Always show
