### PR TITLE
profile.d: use GTK3_MODULES over GTK_MODULES

### DIFF
--- a/profile.d/pantheon-filechooser-module.sh
+++ b/profile.d/pantheon-filechooser-module.sh
@@ -1,1 +1,1 @@
-export GTK_MODULES="$GTK_MODULES:pantheon-filechooser-module"
+export GTK3_MODULES="${GTK3_MODULES:-}${GTK3_MODULES:+:}pantheon-filechooser-module"


### PR DESCRIPTION
The docs on GTK_MODULES states this
> Note that this environment variable is read by GTK+ 2.x too, which may not have the same set of modules available for loading. Use GTK3_MODULES for modules that are only compatible with GTK+ 3. 

and this module is only compatible with GTK 3, so we should be using `GTK3_MODULES`.

This typically produces some benign warnings in the outputs like:
Gtk-WARNING **: 13:33:12.201: GTK+ module /run/current-system/sw/lib/gtk-3.0/modules/libpantheon-filechooser-module.so cannot be loaded.
GTK+ 2.x symbols detected. Using GTK+ 2.x and GTK+ 3 in the same process is not supported.
Gtk-Message: 13:33:12.202: Failed to load module "pantheon-filechooser-module"

We also use safer parameter expansions, see https://wiki-dev.bash-hackers.org/syntax/pe#use_an_alternate_value and
https://wiki-dev.bash-hackers.org/syntax/pe#use_a_default_value.