### PR TITLE
default-settings.gschema.override: Remove old show-desktop-icons

### DIFF
--- a/overrides/default-settings.gschema.override
+++ b/overrides/default-settings.gschema.override
@@ -15,7 +15,6 @@ show=1
 picture-options='zoom'
 picture-uri='file:///usr/share/backgrounds/elementaryos-default'
 primary-color='#000000'
-show-desktop-icons=false
 
 [org.gnome.desktop.datetime]
 automatic-timezone=true


### PR DESCRIPTION
I highly doubt this actually does anything anymore