### PR TITLE
Plank: Tweak delay values

### DIFF
--- a/overrides/default-settings.gschema.override
+++ b/overrides/default-settings.gschema.override
@@ -1,9 +1,10 @@
 [net.launchpad.plank.dock.settings]
 dock-items=['gala-multitaskingview.dockitem','org.gnome.Epiphany.dockitem','org.pantheon.mail.dockitem','io.elementary.calendar.dockitem','io.elementary.music.dockitem','io.elementary.videos.dockitem','io.elementary.photos.dockitem','io.elementary.switchboard.dockitem','io.elementary.appcenter.dockitem']
-hide-delay=250
+hide-delay=500
 hide-mode='window-dodge'
 show-dock-item=false
 theme='Gtk+'
+unhide-delay=250
 
 [org.freedesktop.ibus.general.hotkey]
 triggers=['<Control>space']


### PR DESCRIPTION
I've been using these values for a while and it accomplishes a couple of things, making the dock feel less "twitchy" to me:

1. Plank hangs around a bit longer before hiding. This makes it feel more explicit that it's hiding, especially when maximizing a window (it waits until the maximize is done, then hides).
2. Sort of emulates pressure reveal, preventing accidental reveals when brushing against the bottom of the display. This makes it require a little more intentional action to reveal the dock.

Together I think these feel nice, but I'm fine trying to tune them a bit more.