### PR TITLE
focal: fix media keys syntax

### DIFF
--- a/overrides/default-settings.gschema.override
+++ b/overrides/default-settings.gschema.override
@@ -131,8 +131,7 @@ active=false
 night-light-temperature=4500
 
 [org.gnome.settings-daemon.plugins.media-keys]
-screensaver='<Super>l'
-terminal='<Super>t'
+terminal=['<Super>t']
 
 [org.gnome.settings-daemon.plugins.power]
 idle-dim=false


### PR DESCRIPTION
These need to go in an array now and it seems `<Super>l` is already the default screensaver shortcut