### PR TITLE
AccountsService: Change PrefersColorScheme to enum

### DIFF
--- a/accountsservice/io.elementary.pantheon.AccountsService.xml
+++ b/accountsservice/io.elementary.pantheon.AccountsService.xml
@@ -16,8 +16,8 @@
       <annotation name="org.freedesktop.Accounts.DefaultValue.String" value="24h"/>
     </property>
 
-    <property name="PrefersColorScheme" type="s" access="readwrite">
-      <annotation name="org.freedesktop.Accounts.DefaultValue.String" value="no-preference"/>
+    <property name="PrefersColorScheme" type="u" access="readwrite">
+      <annotation name="org.freedesktop.Accounts.DefaultValue.String" value="0"/>
     </property>
 
     <property name="SleepInactiveACTimeout" type="i" access="readwrite">

--- a/accountsservice/io.elementary.pantheon.AccountsService.xml
+++ b/accountsservice/io.elementary.pantheon.AccountsService.xml
@@ -24,7 +24,7 @@
       Unrecognized statuses should be considered equal to No Preference.
     -->
     <property name="PrefersColorScheme" type="u" access="readwrite">
-      <annotation name="org.freedesktop.Accounts.DefaultValue.String" value="0"/>
+      <annotation name="org.freedesktop.Accounts.DefaultValue" value="0"/>
     </property>
 
     <property name="SleepInactiveACTimeout" type="i" access="readwrite">

--- a/accountsservice/io.elementary.pantheon.AccountsService.xml
+++ b/accountsservice/io.elementary.pantheon.AccountsService.xml
@@ -16,6 +16,13 @@
       <annotation name="org.freedesktop.Accounts.DefaultValue.String" value="24h"/>
     </property>
 
+    <!--
+      PrefersColorScheme:
+
+      What color scheme the user prefers for the UI.
+      Valid statuses: 0 = No Preference, 1 = Prefer Dark, 2 = Prefer Light.
+      Unrecognized statuses should be considered equal to No Preference.
+    -->
     <property name="PrefersColorScheme" type="u" access="readwrite">
       <annotation name="org.freedesktop.Accounts.DefaultValue.String" value="0"/>
     </property>


### PR DESCRIPTION
From https://dbus.freedesktop.org/doc/dbus-api-design.html:

>In particular, sending structured strings over D-Bus should be avoided, as they need to be built and parsed; both are complex operations which are prone to bugs.
>For APIs being used in constrained situations, enumerated values should be transmitted as unsigned integers.

It sounds like it is expected to be implemented as an enum on the client side and then just send the int over DBus. In this case we would use:

- `0` no preference
- `1` prefer dark
- `2` prefer light