### PR TITLE
Enable screensaver locking by default

### DIFF
--- a/overrides/default-settings.gschema.override.in
+++ b/overrides/default-settings.gschema.override.in
@@ -37,9 +37,6 @@ show-unicode-menu=false
 natural-scroll=true
 tap-to-click=true
 
-[org.gnome.desktop.screensaver]
-lock-enabled=false
-
 [org.gnome.desktop.sound]
 theme-name='elementary'
 


### PR DESCRIPTION
This would have been disabled to stop it interfering with light-locker as much I guess. But since we now intend to use this key to enable/disable our Gala screen locker when the session goes idle, we should let it revert back to the GNOME default of true.