### PR TITLE
accountsservice: Add keys for keyboard layout

### DIFF
--- a/accountsservice/io.elementary.pantheon.AccountsService.xml
+++ b/accountsservice/io.elementary.pantheon.AccountsService.xml
@@ -43,5 +43,13 @@
       <annotation name="org.freedesktop.Accounts.DefaultValue" value="1"/>
     </property>
 
+    <property name="KeyboardLayouts" type="a(ss)" access="readwrite">
+      <annotation name="org.freedesktop.Accounts.DefaultValue" value="[]"/>
+    </property>
+
+    <property name="ActiveKeyboardLayout" type="u" access="readwrite">
+      <annotation name="org.freedesktop.Accounts.DefaultValue" value="0"/>
+    </property>
+
   </interface>
 </node>


### PR DESCRIPTION
Adds two keys to mirror the keys in `org.gnome.desktop.input-sources` so that we can synchronise keyboard layouts between user sessions and the greeter.

These will also be useful for initial setup to initially set the keyboard layout on a new user once created.