### PR TITLE
Set default idle delay to 15 minutes

### DIFF
--- a/overrides/default-settings.gschema.override.in
+++ b/overrides/default-settings.gschema.override.in
@@ -41,6 +41,9 @@ tap-to-click=true
 remove-old-temp-files=true
 remove-old-trash-files=true
 
+[org.gnome.desktop.session]
+idle-delay=900
+
 [org.gnome.desktop.sound]
 theme-name='elementary'
 


### PR DESCRIPTION
This is the key that controls how long the session can be idle for before the screen is blanked. This was previously controlled by DPMS helper and the default was 15 minutes, so this allows us to have the same default.