### PR TITLE
AccountsService: Add PrefersAccentColor to users

### DIFF
--- a/accountsservice/io.elementary.pantheon.AccountsService.xml
+++ b/accountsservice/io.elementary.pantheon.AccountsService.xml
@@ -17,6 +17,21 @@
     </property>
 
     <!--
+      PrefersAccentColor:
+
+      What accent color the user prefers for the UI.
+
+      Valid preferences: 0 = No Preference (currently assumes Blueberry), 
+      1 = Strawberry, 2 = Orange, 3 = Banana, 4 = Lime, 5 = Blueberry, 6 = Mint, 
+      7 = Grape, 8 = Bubblegum, 9 = Cocoa, 10 = Slate.
+
+      Unrecognized preferences should be considered equal to No Preference.
+    -->
+    <property name="PrefersAccentColor" type="i" access="readwrite">
+      <annotation name="org.freedesktop.Accounts.DefaultValue" value="0"/>
+    </property>
+
+    <!--
       PrefersColorScheme:
 
       What color scheme the user prefers for the UI.

--- a/accountsservice/io.elementary.pantheon.AccountsService.xml
+++ b/accountsservice/io.elementary.pantheon.AccountsService.xml
@@ -21,9 +21,18 @@
 
       What accent color the user prefers for the UI.
 
-      Valid preferences: 0 = No Preference (currently assumes Blue), 1 = Red, 
-      2 = Orange, 3 = Yellow, 4 = Green, 6 = Mint, 6 = Blue, 7 = Purple, 
-      8 = Pink, 9 = Brown, 10 = Gray.
+      Valid preferences: 
+        0 = No Preference (currently assumes Blue)
+        1 = Red
+        2 = Orange
+        3 = Yellow
+        4 = Green
+        5 = Mint
+        6 = Blue
+        7 = Purple
+        8 = Pink
+        9 = Brown
+        10 = Gray
 
       Unrecognized preferences should be considered equal to No Preference.
     -->

--- a/accountsservice/io.elementary.pantheon.AccountsService.xml
+++ b/accountsservice/io.elementary.pantheon.AccountsService.xml
@@ -21,9 +21,9 @@
 
       What accent color the user prefers for the UI.
 
-      Valid preferences: 0 = No Preference (currently assumes Blueberry), 
-      1 = Strawberry, 2 = Orange, 3 = Banana, 4 = Lime, 5 = Blueberry, 6 = Mint, 
-      7 = Grape, 8 = Bubblegum, 9 = Cocoa, 10 = Slate.
+      Valid preferences: 0 = No Preference (currently assumes Blue), 1 = Red, 
+      2 = Orange, 3 = Yellow, 4 = Green, 5 = Blue, 6 = Mint, 7 = Purple, 
+      8 = Pink, 9 = Brown, 10 = Gray.
 
       Unrecognized preferences should be considered equal to No Preference.
     -->

--- a/accountsservice/io.elementary.pantheon.AccountsService.xml
+++ b/accountsservice/io.elementary.pantheon.AccountsService.xml
@@ -22,7 +22,7 @@
       What accent color the user prefers for the UI.
 
       Valid preferences: 0 = No Preference (currently assumes Blue), 1 = Red, 
-      2 = Orange, 3 = Yellow, 4 = Green, 5 = Blue, 6 = Mint, 7 = Purple, 
+      2 = Orange, 3 = Yellow, 4 = Green, 6 = Mint, 6 = Blue, 7 = Purple, 
       8 = Pink, 9 = Brown, 10 = Gray.
 
       Unrecognized preferences should be considered equal to No Preference.


### PR DESCRIPTION
Will fix #175. Open to feedback.

My reason for having `0` equal "No Preference" while also having blue is because it seemed the most flexible if we wanted to change how the accent color stuff worked down the line, without hardcoding the default to blue. But maybe this is overthinking it.