### PR TITLE
org.gnome.Epiphany.dockitem: Point to Flatpak

### DIFF
--- a/skel/plank/dock1/launchers/org.gnome.Epiphany.dockitem
+++ b/skel/plank/dock1/launchers/org.gnome.Epiphany.dockitem
@@ -1,2 +1,2 @@
 [PlankDockItemPreferences]
-Launcher=file:///usr/share/applications/org.gnome.Epiphany.desktop
+Launcher=file:///var/lib/flatpak/exports/share/applications/org.gnome.Epiphany.desktop


### PR DESCRIPTION
Gets Epiphany back into the dock.