### PR TITLE
Force the use of the portal by default for native GTK widgets

### DIFF
--- a/profile.d/gtk-filechooser-native.sh
+++ b/profile.d/gtk-filechooser-native.sh
@@ -1,0 +1,1 @@
+export GTK_USE_PORTAL=1


### PR DESCRIPTION
As defined in https://gitlab.gnome.org/GNOME/gtk/-/blob/master/gdk/gdk.c#L384