### PR TITLE
Control: remove recommends covered by seeds

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: elementary-default-settings
 Section: gnome
 Priority: optional
-Maintainer: Cody Garver <cody@elementary.io>
+Maintainer: elementary, Inc. <builds@elementary.io>
 Build-Depends: debhelper (>= 10.5.1),
                libaccountsservice-dev,
                libdbus-1-dev,
@@ -12,7 +12,6 @@ Standards-Version: 4.1.1
 Package: elementary-default-settings
 Architecture: all
 Depends: libglib2.0-bin, qt5-gtk-platformtheme, adwaita-qt, elementary-icon-theme, ${misc:Depends}
-Recommends: io.elementary.terminal
 Replaces: libgtk-3-0
 Enhances: plank
 Description: Default settings for elementary OS

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Standards-Version: 4.1.1
 Package: elementary-default-settings
 Architecture: all
 Depends: libglib2.0-bin, qt5-gtk-platformtheme, adwaita-qt, elementary-icon-theme, ${misc:Depends}
-Recommends: noise, pantheon-terminal
+Recommends: io.elementary.terminal
 Replaces: libgtk-3-0
 Enhances: plank
 Description: Default settings for elementary OS


### PR DESCRIPTION
Possibly fixes: https://github.com/elementary/os/issues/432 and/or https://github.com/elementary/appcenter/issues/1470

This seems like some weird historical crap from before we had seeds https://github.com/elementary/default-settings/commit/3b8d347a0fbe240904f394b57ef9c367b072c3c0