### PR TITLE
Remove old profile shell scripts on upgrade

### DIFF
--- a/debian/elementary-default-settings.maintscript
+++ b/debian/elementary-default-settings.maintscript
@@ -1,0 +1,2 @@
+rm_conffile /etc/profile.d/gtk-csd.sh 6.0.0~
+rm_conffile /etc/profile.d/gtk-filechooser-native.sh 6.0.0~


### PR DESCRIPTION
Even though we've now removed these config files from the package, dpkg won't automatically remove them when newer versions of the package are installed because it doesn't remove config.

This change causes them to be deleted (unless the user has modified them) if the new version of the package being installed <= 6.0.0, so it'll work with the stable release of the package in the future too.