### PR TITLE
GSettings override: Use WingPanel RDNN for Gala

### DIFF
--- a/overrides/default-settings.gschema.override.in
+++ b/overrides/default-settings.gschema.override.in
@@ -151,7 +151,7 @@ theme='/usr/share/onboard/themes/Nightshade.theme'
 
 [org.pantheon.desktop.gala.behavior:Pantheon]
 overlay-action='io.elementary.shortcut-overlay'
-panel-main-menu-action='wingpanel --toggle-indicator=app-launcher'
+panel-main-menu-action='io.elementary.wingpanel --toggle-indicator=app-launcher'
 
 [org.pantheon.desktop.gala.notifications.applications.gala-other:Pantheon]
 bubbles=false


### PR DESCRIPTION
We missed this, and it fixes launching the applications menu with a keyboard shortcut. Why are we doing this here, anyway??