### PR TITLE
Remove pantheon-filechooser-module.sh

### DIFF
--- a/debian/elementary-default-settings.maintscript
+++ b/debian/elementary-default-settings.maintscript
@@ -1,2 +1,3 @@
 rm_conffile /etc/profile.d/gtk-csd.sh 6.0.0~
 rm_conffile /etc/profile.d/gtk-filechooser-native.sh 6.0.0~
+rm_conffile /etc/profile.d/pantheon-filechooser-module.sh 6.0.0~

--- a/profile.d/pantheon-filechooser-module.sh
+++ b/profile.d/pantheon-filechooser-module.sh
@@ -1,1 +1,0 @@
-export GTK3_MODULES="${GTK3_MODULES:-}${GTK3_MODULES:+:}pantheon-filechooser-module"


### PR DESCRIPTION
We no longer have this module in 6.0. We should stop pushing it into the environment variables as it causes a warning about it being missing every time you start a GTK app from the terminal.