### PR TITLE
PrefersAccentColor: default to blue

### DIFF
--- a/accountsservice/io.elementary.pantheon.AccountsService.xml
+++ b/accountsservice/io.elementary.pantheon.AccountsService.xml
@@ -37,7 +37,7 @@
       Unrecognized preferences should be considered equal to No Preference.
     -->
     <property name="PrefersAccentColor" type="i" access="readwrite">
-      <annotation name="org.freedesktop.Accounts.DefaultValue" value="0"/>
+      <annotation name="org.freedesktop.Accounts.DefaultValue" value="6"/>
     </property>
 
     <!--


### PR DESCRIPTION
Unless we want to ship grape by default, no preference isn't the correct default here. This makes blueberry the default.