### PR TITLE
Mail dockitem: Update to Flatpak path

### DIFF
--- a/skel/plank/dock1/launchers/io.elementary.mail.dockitem
+++ b/skel/plank/dock1/launchers/io.elementary.mail.dockitem
@@ -1,2 +1,2 @@
 [PlankDockItemPreferences]
-Launcher=file:///usr/share/applications/io.elementary.mail.desktop
+Launcher=file:///var/lib/flatpak/exports/share/applications/io.elementary.mail.desktop


### PR DESCRIPTION
Fixes Mail not showing in the dock on latest daily images