### PR TITLE
Add LightDM AppArmor profile

### DIFF
--- a/apparmor.d/io.elementary.lightdm-guest-session
+++ b/apparmor.d/io.elementary.lightdm-guest-session
@@ -10,9 +10,6 @@
   # Prevent ICEauthority error in e.g. MATE
   owner /{,var/}run/user/[0-9]*/ICEauthority* l,
 
-  # chromium-browser needs special confinement due to its sandboxing
-  #include <abstractions/lightdm_chromium-browser>
-
   # fcitx and friends needs special treatment due to C/S design
   /usr/bin/fcitx ix,
   /tmp/fcitx-socket-* rwl,

--- a/apparmor.d/io.elementary.lightdm-guest-session
+++ b/apparmor.d/io.elementary.lightdm-guest-session
@@ -1,0 +1,33 @@
+# vim:syntax=apparmor
+# Profile for restricting lightdm guest session
+
+#include <tunables/global>
+
+/usr/lib/lightdm/lightdm-guest-session {
+  # Most applications are confined via the main abstraction
+  #include <abstractions/lightdm>
+
+  # Prevent ICEauthority error in e.g. MATE
+  owner /{,var/}run/user/[0-9]*/ICEauthority* l,
+
+  # chromium-browser needs special confinement due to its sandboxing
+  #include <abstractions/lightdm_chromium-browser>
+
+  # fcitx and friends needs special treatment due to C/S design
+  /usr/bin/fcitx ix,
+  /tmp/fcitx-socket-* rwl,
+  /dev/shm/* rwl,
+  /usr/bin/fcitx-qimpanel ix,
+  /usr/bin/sogou-qimpanel-watchdog ix,
+  /usr/bin/sogou-sys-notify ix,
+  /tmp/sogou-qimpanel:* rwl,
+
+  # Allow ibus
+  unix (bind, listen) type=stream addr="@tmp/ibus/*",
+
+  # mozc_server needs special treatment due to C/S design
+  unix (bind, listen) type=stream addr="@tmp/.mozc.*",
+
+  # Allow applications-menu to connect to switchboard for settings search
+  unix (bind, listen) type=stream addr="@/tmp/applications-menu*",
+}

--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Section: gnome
 Priority: optional
 Maintainer: elementary, Inc. <builds@elementary.io>
 Build-Depends: debhelper (>= 10.5.1),
+               dh-apparmor,
                libaccountsservice-dev,
                libdbus-1-dev,
                libpolkit-gobject-1-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -2,3 +2,7 @@
 
 %:
 	dh $@ --buildsystem=meson
+
+override_dh_install:
+	dh_install
+	dh_apparmor --profile-name=io.elementary.lightdm-guest-session

--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,13 @@ install_subdir(
     strip_directory : true
 )
 
+# Install apparmor profiles
+install_subdir(
+    'apparmor.d',
+    install_dir: sysconfdir / 'apparmor.d'),
+    strip_directory : true
+)
+
 # Sudo password feedback in terminals
 install_data(
     'sudoers.d/pwfeedback',

--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,7 @@ install_subdir(
 # Install apparmor profiles
 install_subdir(
     'apparmor.d',
-    install_dir: sysconfdir / 'apparmor.d'),
+    install_dir: sysconfdir / 'apparmor.d',
     strip_directory : true
 )
 


### PR DESCRIPTION
theoretically fixes https://github.com/elementary/applications-menu/issues/393 by providing an apparmor profile for the guest session that allows the applications menu to talk to settings search