### PR TITLE
Revert "Mail dockitem: Update to Flatpak path (#234)"

### DIFF
--- a/skel/plank/dock1/launchers/io.elementary.mail.dockitem
+++ b/skel/plank/dock1/launchers/io.elementary.mail.dockitem
@@ -1,2 +1,2 @@
 [PlankDockItemPreferences]
-Launcher=file:///var/lib/flatpak/exports/share/applications/io.elementary.mail.desktop
+Launcher=file:///usr/share/applications/io.elementary.mail.desktop


### PR DESCRIPTION
This reverts commit e48798b5ab0818f019702860df0535cb79a109aa due to https://github.com/elementary/os/pull/496 and https://github.com/elementary/seeds/pull/77