### PR TITLE
GSchema: Remove nonfunctional notifications override

### DIFF
--- a/overrides/default-settings.gschema.override.in
+++ b/overrides/default-settings.gschema.override.in
@@ -152,8 +152,3 @@ theme='/usr/share/onboard/themes/Nightshade.theme'
 [org.pantheon.desktop.gala.behavior:Pantheon]
 overlay-action='io.elementary.shortcut-overlay'
 panel-main-menu-action='io.elementary.wingpanel --toggle-indicator=app-launcher'
-
-[org.pantheon.desktop.gala.notifications.applications.gala-other:Pantheon]
-bubbles=false
-remember=false
-sounds=false


### PR DESCRIPTION
This never worked, plus it's RDNN under `io.elementary.notifications` now anyway.