### PR TITLE
GSchema: Remove Plank settings overrides

### DIFF
--- a/overrides/default-settings.gschema.override.in
+++ b/overrides/default-settings.gschema.override.in
@@ -1,9 +1,3 @@
-[net.launchpad.plank.dock.settings:Pantheon]
-hide-delay=250
-hide-mode='window-dodge'
-show-dock-item=false
-theme='Gtk+'
-
 [org.freedesktop.ibus.general.hotkey:Pantheon]
 triggers=['<Control>space']
 


### PR DESCRIPTION
Depends on https://github.com/elementary/dock/pull/108. Retains the dockitem override in its separate file.