### PR TITLE
Fix warnings introduced by Gnome 40+ and last versions of Epiphany

### DIFF
--- a/overrides/default-settings.gschema.override.in
+++ b/overrides/default-settings.gschema.override.in
@@ -94,7 +94,6 @@ expand-tabs-bar=false
 tabs-bar-visibility-policy='always'
 
 [org.gnome.Epiphany.web:Pantheon]
-cookies-policy='no-third-party'
 enable-adblock=false
 enable-smooth-scrolling=true
 

--- a/overrides/default-settings.gschema.override.in
+++ b/overrides/default-settings.gschema.override.in
@@ -95,7 +95,6 @@ tabs-bar-visibility-policy='always'
 
 [org.gnome.Epiphany.web:Pantheon]
 enable-adblock=false
-enable-smooth-scrolling=true
 
 [org.gnome.mutter:Pantheon]
 auto-maximize=false

--- a/overrides/default-settings.gschema.override.in
+++ b/overrides/default-settings.gschema.override.in
@@ -21,11 +21,12 @@ xkb-options=['grp:alt_shift_toggle']
 [org.gnome.desktop.interface:Pantheon]
 cursor-theme='elementary'
 document-font-name='Open Sans 10'
+font-antialiasing='grayscale'
+font-hinting='slight'
 font-name='Inter 9'
 gtk-theme='io.elementary.stylesheet.blueberry'
 icon-theme='elementary'
 monospace-font-name='Roboto Mono 10'
-show-unicode-menu=false
 
 [org.gnome.desktop.peripherals.touchpad:Pantheon]
 natural-scroll=true
@@ -133,9 +134,7 @@ idle-dim=false
 active=false
 
 [org.gnome.settings-daemon.plugins.xsettings:Pantheon]
-antialiasing='grayscale'
-hinting='slight'
-overrides={'Gtk/DialogsUseHeader': <0>, 'Gtk/EnablePrimaryPaste': <0>, 'Gtk/ShellShowsAppMenu': <0>, 'Gtk/DecorationLayout': <'close:menu,maximize'>}
+overrides={'Gtk/DialogsUseHeader': <0>, 'Gtk/EnablePrimaryPaste': <0>, 'Gtk/ShellShowsAppMenu': <0>, 'Gtk/DecorationLayout': <'close:menu,maximize'>,'Gtk/ShowUnicodeMenu': <0>}
 
 [org.gtk.Settings.FileChooser:Pantheon]
 sort-directories-first=true


### PR DESCRIPTION
Fixes #259 
Fixes #258 
Fixes #260

This MR migrates font settings to their new schema.

It also move the `show-unicode-menu` in the deprecated area.

Finally, it removes now useless Epiphany settings, which are either replaced by something else (cookie setting) and in both case activated by default.