### PR TITLE
Set default monospace font

### DIFF
--- a/gtk/settings.ini
+++ b/gtk/settings.ini
@@ -5,3 +5,4 @@ gtk-fallback-icon-theme = gnome
 gtk-sound-theme-name = elementary
 gtk-icon-sizes = panel-menu-bar=24,24
 gtk-font-name = Inter 9
+gtk-monospace-font-name = Cascadia Code PL 10


### PR DESCRIPTION
this is related to https://github.com/elementary/fonts/pull/20 and https://github.com/elementary/default-settings/issues/92

I didn't know if it was appropriate to remove Roboto Mono, but I can do that as well.