### PR TITLE
Music Dockitem: Point to var/lib/flatpak

### DIFF
--- a/skel/plank/dock1/launchers/io.elementary.music.dockitem
+++ b/skel/plank/dock1/launchers/io.elementary.music.dockitem
@@ -1,2 +1,2 @@
 [PlankDockItemPreferences]
-Launcher=file:///usr/share/applications/io.elementary.music.desktop
+Launcher=file:///var/lib/flatpak/exports/share/applications/io.elementary.music.desktop


### PR DESCRIPTION
Fixes missing Music from the Dock in OS 7