### PR TITLE
deb-packaging: Divert printer test page instead of replacing whole package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Package: elementary-printer-test-page
 Architecture: all
 Depends: ${misc:Depends}
 Conflicts: print-test-page-elementary
-Replaces: cups-filters, print-test-page-elementary
+Replaces: print-test-page-elementary
 Description: printer test page for elementary
  Printer test page for elementary OS.
 

--- a/debian/elementary-printer-test-page.postrm
+++ b/debian/elementary-printer-test-page.postrm
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+if [ remove = "$1" -o abort-install = "$1" -o disappear = "$1" ]; then
+    dpkg-divert --package elementary-printer-test-page --remove --rename \
+        --divert /usr/share/cups/data/default-testpage.pdf.real /usr/share/cups/data/default-testpage.pdf
+fi

--- a/debian/elementary-printer-test-page.preinst
+++ b/debian/elementary-printer-test-page.preinst
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+dpkg-divert --package elementary-printer-test-page --add --rename \
+    --divert /usr/share/cups/data/default-testpage.pdf.real /usr/share/cups/data/default-testpage.pdf


### PR DESCRIPTION
We shouldn't really be replacing the `cups-filters` package with a single PDF as it has a bunch more useful stuff than just the test page.

Additionally, this `cups-filters` package has now been renamed, so I'm now ending up with installation failures on `mantic` due to two packages trying to install the test page. So we should do this properly and just divert the one file we want to replace.