### PR TITLE
Do Not Set a Default Dark Wallpaper

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,7 +10,7 @@ option('default-wallpaper',
 
 option('default-wallpaper-dark',
        type: 'string',
-       value: '/usr/share/backgrounds/elementaryos-default',
+       value: '',
        description: 'Path to dark wallpaper to use in Pantheon.')
 
 option('plank-dockitems',


### PR DESCRIPTION
We don't have a dark wallpaper currently, and don't support changing it in switchboard either. As such we shouldn't set a dark wallpaper uri as the default, as it makes gala change the user selected wallpaper to the elementary default one.