### PR TITLE
Disable ibus emoji hotkeys

### DIFF
--- a/overrides/default-settings.gschema.override.in
+++ b/overrides/default-settings.gschema.override.in
@@ -4,6 +4,10 @@ triggers=['<Control>space']
 [org.freedesktop.ibus.panel:Pantheon]
 show=1
 
+[org.freedesktop.ibus.panel.emoji:Pantheon]
+hotkey=[]
+unicode-hotkey=[]
+
 [org.gnome.desktop.background:Pantheon]
 picture-options='zoom'
 picture-uri='file://@DEFAULT_WALLPAPER@'


### PR DESCRIPTION
Fixes https://github.com/elementary/triage/issues/18

Disables Ctrl + Period, Ctrl + Semicolon and Ctrl + Shift + U shortcuts