### PR TITLE
Make Qt overrides Pantheon-exclusive

### DIFF
--- a/profile.d/qt-qpa-platformtheme.sh
+++ b/profile.d/qt-qpa-platformtheme.sh
@@ -1,1 +1,3 @@
-export QT_QPA_PLATFORMTHEME=gtk3
+if [ -z "$QT_QPA_PLATFORMTHEME" ] && [ "$XDG_CURRENT_DESKTOP" == "Pantheon" ] then
+  export QT_QPA_PLATFORMTHEME=gtk3
+fi

--- a/profile.d/qt-qpa-platformtheme.sh
+++ b/profile.d/qt-qpa-platformtheme.sh
@@ -1,3 +1,3 @@
-if [ -z "$QT_QPA_PLATFORMTHEME" ] && [ "$XDG_CURRENT_DESKTOP" == "Pantheon" ] then
+if [ -z "$QT_QPA_PLATFORMTHEME" ] && [ "$XDG_CURRENT_DESKTOP" == "Pantheon" ]; then
   export QT_QPA_PLATFORMTHEME=gtk3
 fi

--- a/profile.d/qt-style-override.sh
+++ b/profile.d/qt-style-override.sh
@@ -1,1 +1,3 @@
-export QT_STYLE_OVERRIDE=adwaita
+if [ -z "$QT_STYLE_OVERRIDE" ] && [ "$XDG_CURRENT_DESKTOP" == "Pantheon" ] then
+  export QT_STYLE_OVERRIDE=adwaita
+fi

--- a/profile.d/qt-style-override.sh
+++ b/profile.d/qt-style-override.sh
@@ -1,3 +1,3 @@
-if [ -z "$QT_STYLE_OVERRIDE" ] && [ "$XDG_CURRENT_DESKTOP" == "Pantheon" ] then
+if [ -z "$QT_STYLE_OVERRIDE" ] && [ "$XDG_CURRENT_DESKTOP" == "Pantheon" ]; then
   export QT_STYLE_OVERRIDE=adwaita
 fi


### PR DESCRIPTION
Distributions should not override Qt settings, using variables, outside of their intended Desktop Environment(s). Doing so will only break Qt in other Desktop Environments, especially first-class ones including KDE Plasma. 

This merge request rectifies this by making the overrides only activate inside Pantheon. 