### PR TITLE
Add beacondb for GeoClue

### DIFF
--- a/geoclue/beacondb.conf
+++ b/geoclue/beacondb.conf
@@ -1,0 +1,3 @@
+[wifi]
+enable=true
+url=https://api.beacondb.net/v1/geolocate

--- a/geoclue/beacondb.conf
+++ b/geoclue/beacondb.conf
@@ -1,3 +1,3 @@
 [wifi]
 enable=true
-url=https://api.beacondb.net/v1/geolocate
+url=https://api.beacondb.net/v1/geolocate?key=geoclue_elementaryos

--- a/geoclue/meson.build
+++ b/geoclue/meson.build
@@ -1,0 +1,5 @@
+install_data(
+    'beacondb.conf',
+    rename: '99-beacondb.conf',
+    install_dir: sysconfdir / 'geoclue' / 'conf.d'
+)

--- a/meson.build
+++ b/meson.build
@@ -47,5 +47,8 @@ subdir('accountsservice')
 # System skeleton
 subdir('skel')
 
+# Geolocation settings
+subdir('geoclue')
+
 # GTK settings
 subdir('gtk')


### PR DESCRIPTION
Fixes https://github.com/elementary/triage/issues/702

Adds a conf file for https://beacondb.net/ so we can get wifi location with GeoClue again

Identify user agent manually as requested at https://codeberg.org/beacondb/beacondb/issues/5#issuecomment-2504311