### PR TITLE
Meson: make geoclue conf optional

### DIFF
--- a/geoclue/meson.build
+++ b/geoclue/meson.build
@@ -1,5 +1,5 @@
 # Configure GeoClue to use BeaconDB
-if get_option('appcenter-flatpak')
+if get_option('geoclue')
     install_data(
         'beacondb.conf',
         rename: '99-beacondb.conf',

--- a/geoclue/meson.build
+++ b/geoclue/meson.build
@@ -1,5 +1,8 @@
-install_data(
-    'beacondb.conf',
-    rename: '99-beacondb.conf',
-    install_dir: sysconfdir / 'geoclue' / 'conf.d'
-)
+# Configure GeoClue to use BeaconDB
+if get_option('appcenter-flatpak')
+    install_data(
+        'beacondb.conf',
+        rename: '99-beacondb.conf',
+        install_dir: sysconfdir / 'geoclue' / 'conf.d'
+    )
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,3 +17,8 @@ option('default-gsettings-overrides',
        type: 'boolean',
        value: true,
        description: 'Install default Pantheon GSettings Overrides')
+
+option('geoclue',
+       type: 'boolean',
+       value: true,
+       description: 'Install configuration files for GeoClue')


### PR DESCRIPTION
Make geoclue conf optional since some distros ship their own