### PR TITLE
Flatpak: add accessibility overrides

### DIFF
--- a/skel/flatpak/overrides/global
+++ b/skel/flatpak/overrides/global
@@ -1,0 +1,6 @@
+[Environment]
+QT_LINUX_ACCESSIBILITY_ALWAYS=true
+GTK_PATH=/app/lib/gtkmodules
+
+[Session Bus Policy]
+org.a11y.bus=talk


### PR DESCRIPTION
Fixes https://github.com/elementary/default-settings/issues/342

This will only apply to new users, so... we probably should create this file manually in packaging I guess. Also it doesn't apply to system applications so I need to figure out how to write this file in /var/lib/flatpak/overrides. If you know how to do this feel free to push into this branch.