### PR TITLE
Remove outdated x11 overrides

### DIFF
--- a/overrides/default-settings.gschema.override.in
+++ b/overrides/default-settings.gschema.override.in
@@ -134,7 +134,7 @@ eject-static=[]
 idle-dim=false
 
 [org.gnome.settings-daemon.plugins.xsettings:Pantheon]
-overrides={'Gtk/DialogsUseHeader': <0>, 'Gtk/EnablePrimaryPaste': <0>, 'Gtk/ShellShowsAppMenu': <0>, 'Gtk/DecorationLayout': <'close:menu,maximize'>,'Gtk/ShowUnicodeMenu': <0>}
+overrides={'Gtk/DialogsUseHeader': <0>}
 
 [org.gnome.system.location:Pantheon]
 enabled=true


### PR DESCRIPTION
Gtk/EnablePrimaryPaste and Gtk/DecorationLayout are automatically synced with their appropriate settings by gsd-xsettings. Gtk/ShellShowsAppMenu and Gtk/ShowUnicodeMenu are set to false by default.

Gtk/DialogsUseHeader defaults to true, so I kept it in place.