### PR TITLE
Control: fix maintainer field

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: elementary-default-settings
 Section: gnome
 Priority: optional
-Maintainer: elementary, Inc. <builds@elementary.io>
+Maintainer: elementary <builds@elementary.io>
 Build-Depends: debhelper (>= 10.5.1),
                libaccountsservice-dev,
                libdbus-1-dev,


### PR DESCRIPTION
Fix build for Resolute is failing on Launchpad:

https://code.launchpad.net/~elementary-os/+recipe/default-settings-daily

```
dpkg-buildpackage: info: source package elementary-default-settings
dpkg-buildpackage: info: source version 8.1.1+r455+pkg318~daily~ubuntu26.04.1
dpkg-buildpackage: info: source distribution resolute
dpkg-buildpackage: info: source changed by Launchpad Package Builder <noreply@launchpad.net>
 dpkg-source -i -I.bzr -I.git --before-build .
dpkg-source: error: cannot parse Maintainer field value "elementary, Inc. <builds@elementary.io>"
dpkg-buildpackage: error: dpkg-source -i -I.bzr -I.git --before-build . subprocess failed with exit status 25
[Mon Jun 22 14:04:40 2026]
RUN: /usr/share/launchpad-buildd/bin/in-target scan-for-processes --backend=chroot --series=resolute --abi-tag=amd64 --isa-tag=amd64 RECIPEBRANCHBUILD-4055926
Scanning for processes to kill in build RECIPEBRANCHBUILD-4055926
```