### PR TITLE
Disable the donation reminder by GSD

### DIFF
--- a/overrides/default-settings.gschema.override.in
+++ b/overrides/default-settings.gschema.override.in
@@ -108,6 +108,9 @@ suppress-wireless-networks-available=true
 [org.gnome.settings-daemon.plugins.color:Pantheon]
 night-light-temperature=4500
 
+[org.gnome.settings-daemon.plugins.housekeeping:Pantheon]
+donation-reminder-enabled=false
+
 [org.gnome.settings-daemon.plugins.media-keys:Pantheon]
 terminal=['<Super>t']
 # see https://github.com/elementary/switchboard-plug-keyboard/issues/376#issuecomment-899068830


### PR DESCRIPTION
Disable the donation reminder by GSD which was added in https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/merge_requests/432, because we want to encourage users to donate us elementary (as discussed in https://github.com/elementary/settings-daemon/issues/170), not GNOME Foundation.

This is how it looks like in OS 9:

<img width="413" height="343" alt="Screenshot_elementary-9-daily_2026-08-11_22:05:43" src="https://github.com/user-attachments/assets/b7d447ef-f537-4027-afc1-dac01533de9e" />
