### PR TITLE
deb-packaging: Changes for flatpak-preinstall

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,8 @@ Build-Depends: debhelper-compat (= 13),
                libaccountsservice-dev,
                libdbus-1-dev,
                libpolkit-gobject-1-dev,
-               meson (>= 1.3.0)
+               meson (>= 1.3.0),
+               systemd-dev
 Standards-Version: 4.1.1
 
 Package: elementary-default-settings

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Standards-Version: 4.1.1
 
 Package: elementary-default-settings
 Architecture: all
-Depends: libglib2.0-bin, elementary-icon-theme, ${misc:Depends}
+Depends: libglib2.0-bin, elementary-icon-theme, flatpak (>= 1.17.0), ${misc:Depends}
 Replaces: libgtk-3-0
 Description: Default settings for elementary OS
  This package contains various system defaults for elementary OS.

--- a/debian/elementary-default-settings.postinst
+++ b/debian/elementary-default-settings.postinst
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+
+# Remove the flag file that flatpak-preinstalld.service generates before the DEBHELPER token, where debhelper starts
+# that service, to make sure flatpak preinstall is executed on package update in case we add new default app
+# to the .preinstall file (see "man debhelper" for details about the DEBHELPER token)
+rm -f /var/lib/flatpak/.preinstall-finished
+
+#DEBHELPER#

--- a/debian/install
+++ b/debian/install
@@ -16,3 +16,6 @@ etc/netplan/01-network-manager-all.yml
 etc/NetworkManager/conf.d/10-globally-managed-devices.conf
 usr/share/flatpak/preinstall.d/
 usr/lib/systemd/system/flatpak-preinstalld.service
+var/lib/flatpak/repo/appcenter.trustedkeys.gpg
+var/lib/flatpak/repo/flathub.trustedkeys.gpg
+var/lib/flatpak/repo/config

--- a/debian/install
+++ b/debian/install
@@ -14,3 +14,5 @@ usr/share/glib-2.0/schemas
 usr/share/xdg-desktop-portal
 etc/netplan/01-network-manager-all.yml
 etc/NetworkManager/conf.d/10-globally-managed-devices.conf
+usr/share/flatpak/preinstall.d/
+usr/lib/systemd/system/flatpak-preinstalld.service


### PR DESCRIPTION
Goes after #366 is merged.

Merging this means we no longer publish new releases of default-settings for OS 8 because now we require flatpak 1.17.0 for the preinstall subcommand.

## Checklist
- [x] Builds succeeds with `debuild -us -uc` on the `development-target` Docker container
- [x] Installation succeeds on OS 9
<details>

```
user@Standard-PC-Q35-ICH9-2009-359d943f:~$ sudo apt install ./*.deb
[sudo: authenticate] Password:     
Note, selecting 'elementary-default-settings' instead of './elementary-default-settings_8.1.1_all.deb'
Note, selecting 'elementary-printer-test-page' instead of './elementary-printer-test-page_8.1.1_all.deb'
elementary-printer-test-page is already the newest version (8.1.1).
elementary-printer-test-page set to manually installed.
Upgrading:                  
  elementary-default-settings

Summary:
  Upgrading: 1, Installing: 0, Removing: 0, Not Upgrading: 0
  Download size: 0 B / 13.7 kB
  Space needed: 9,216 B / 52.6 GB available

Continue? [Y/n] 
Get:1 /home/user/elementary-default-settings_8.1.1_all.deb elementary-default-settings all 8.1.1 [13.7 kB]
(Reading database… 154013 files and directories currently installed.)
Preparing to unpack …/elementary-default-settings_8.1.1_all.deb…
update-alternatives: using /usr/share/icons/Adwaita/cursor.theme to provide /usr/share/icons/default/index.theme (x-cursor-th
eme) in auto mode
Unpacking elementary-default-settings (8.1.1) over (8.1.1)…
Setting up elementary-default-settings (8.1.1)…
update-alternatives: using /usr/share/icons/elementary/cursor.theme to provide /usr/share/icons/default/index.theme (x-cursor
-theme) in manual mode
rm: cannot remove '/etc/apparmor.d/bwrap-userns-restrict': No such file or directory
Created symlink '/etc/systemd/system/multi-user.target.wants/flatpak-preinstalld.service' → '/usr/lib/systemd/system/flatpak-
preinstalld.service'.
Processing triggers for desktop-file-utils (0.28-1build1)…
Processing triggers for libglib2.0-0t64:amd64 (2.88.0-1)…
Notice: Download is performed unsandboxed as root as file '/home/user/elementary-default-settings_8.1.1_all.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
user@Standard-PC-Q35-ICH9-2009-359d943f:~$
```

</details>

- [x] The systemd service starts up on system startup and installs Flatpak apps
<details>

```
user@Standard-PC-Q35-ICH9-2009-359d943f:~$ systemctl status flatpak-preinstalld.service 
● flatpak-preinstalld.service - Preinstall Flatpaks
     Loaded: loaded (/usr/lib/systemd/system/flatpak-preinstalld.service; enabled; preset: enabled)
     Active: activating (start) since Thu 2026-08-13 11:51:02 JST; 24s ago
        Job: 180
 Invocation: f6a7671cd74b485dbd4ad53921652240
       Docs: man:flatpak-preinstall(1)
    Process: 972 ExecStart=mkdir -p /var/lib/flatpak/ (code=exited, status=0/SUCCESS)
   Main PID: 979 (flatpak)
      Tasks: 9 (limit: 3387)
     Memory: 1G (peak: 1G)
        CPU: 12.547s
     CGroup: /system.slice/flatpak-preinstalld.service
             └─979 /usr/bin/flatpak preinstall -y

Aug 13 11:51:25 Standard-PC-Q35-ICH9-2009-359d943f flatpak[979]: system: Installed app/io.elementary.camera/x86_64/stable from appcenter
Aug 13 11:51:25 Standard-PC-Q35-ICH9-2009-359d943f flatpak[979]: Installing 7/24…
Aug 13 11:51:25 Standard-PC-Q35-ICH9-2009-359d943f flatpak[979]: Installing 7/24…                        0%  0 bytes/s
Aug 13 11:51:26 Standard-PC-Q35-ICH9-2009-359d943f flatpak[979]: Installing 7/24… ▌                      3%
Aug 13 11:51:26 Standard-PC-Q35-ICH9-2009-359d943f flatpak[979]: Installing 7/24… ▌                      3%
Aug 13 11:51:26 Standard-PC-Q35-ICH9-2009-359d943f flatpak[979]: libostree pull from 'appcenter' for runtime/io.elementary.capnet_assist.Locale/x86_64/stabl>
                                                                 security: GPG: summary+commit 
                                                                 security: SIGN: disabled http: TLS
                                                                 non-delta: meta: 4 content: 1
                                                                 transfer: secs: 0 size: 15.1 kB
Aug 13 11:51:26 Standard-PC-Q35-ICH9-2009-359d943f flatpak[979]: Installing 7/24… ████████████████████ 100%
Aug 13 11:51:26 Standard-PC-Q35-ICH9-2009-359d943f flatpak[979]: system: Pulled runtime/io.elementary.capnet_assist.Locale/x86_64/stable from appcenter
Aug 13 11:51:26 Standard-PC-Q35-ICH9-2009-359d943f flatpak[979]: system: Installed runtime/io.elementary.capnet_assist.Locale/x86_64/stable from appcenter
Aug 13 11:51:26 Standard-PC-Q35-ICH9-2009-359d943f flatpak[979]: Installing 8/24…
user@Standard-PC-Q35-ICH9-2009-359d943f:~$
```

</details>
