### PR TITLE
deb-packaging: Use drop-in flatpakrepo for system-wide remotes

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -15,7 +15,5 @@ usr/share/xdg-desktop-portal
 etc/netplan/01-network-manager-all.yml
 etc/NetworkManager/conf.d/10-globally-managed-devices.conf
 usr/share/flatpak/preinstall.d/
+usr/share/flatpak/remotes.d/
 usr/lib/systemd/system/flatpak-preinstalld.service
-var/lib/flatpak/repo/appcenter.trustedkeys.gpg
-var/lib/flatpak/repo/flathub.trustedkeys.gpg
-var/lib/flatpak/repo/config


### PR DESCRIPTION
Goes with https://github.com/elementary/default-settings/pull/368
