### PR TITLE
flatpak: Explicitly preinstall GL runtime

### DIFF
--- a/flatpak/flathub.preinstall
+++ b/flatpak/flathub.preinstall
@@ -1,0 +1,7 @@
+# This is for org.gnome.Epiphany and io.elementary.capnet-assist.
+# Flatpak won't install the GL runtime alongside these apps because they're published
+# in different repositories (see https://github.com/flatpak/flatpak/issues/3094 for details).
+# So explicitly install here.
+[Flatpak Preinstall org.freedesktop.Platform.GL.default]
+Branch=24.08
+IsRuntime=true

--- a/flatpak/meson.build
+++ b/flatpak/meson.build
@@ -1,9 +1,16 @@
 subdir('remotes.d')
 
-install_data(
+preinstall_files = [
     'appcenter.preinstall',
-    install_dir: datadir / 'flatpak' / 'preinstall.d'
-)
+    'flathub.preinstall',
+]
+
+foreach file : preinstall_files
+    install_data(
+        file,
+        install_dir: datadir / 'flatpak' / 'preinstall.d'
+    )
+endforeach
 
 systemd_system_unit_dir = get_option('systemdsystemunitdir')
 if systemd_system_unit_dir != 'no'


### PR DESCRIPTION
Fixes an issue that Epiphany and capnet-assist renders anything and just shows the following log in the terminal on latest OS 9 Daily.

```
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```

This PR is just an alternative to what we used to do here:

- https://github.com/elementary/browser/blob/89984e4e8d4fd86ba3debe18c19d9583a06f86fe/debian/postinst#L9
- https://github.com/elementary/capnet-assist/blob/71e397e4d2b29c7e7a6abaa50f6e9b84e9aa71a1/debian/postinst#L9

## Checklist
- [x] Running `flatpak preinstall` installs the GL runtime
- [x] Epiphany launches as expected

<details>

```
user@elementary-9-daily:~/work/default-settings$ systemctl status flatpak-preinstalld.service 
○ flatpak-preinstalld.service - Preinstall Flatpaks
     Loaded: loaded (/usr/lib/systemd/system/flatpak-preinstalld.service; enabled; preset: enabled)
     Active: inactive (dead)
  Condition: start condition unmet at Sat 2026-08-15 16:29:06 JST; 3min 51s ago
       Docs: man:flatpak-preinstall(1)

Aug 15 16:29:06 elementary-9-daily systemd[1]: flatpak-preinstalld.service - Preinstall Flatpaks skipped, unmet condition ch>
user@elementary-9-daily:~/work/default-settings$ sudo rm /var/lib/flatpak/.preinstall-finished 
user@elementary-9-daily:~/work/default-settings$ sudo systemctl restart flatpak-preinstalld.service 
user@elementary-9-daily:~/work/default-settings$ systemctl status flatpak-preinstalld.service 
● flatpak-preinstalld.service - Preinstall Flatpaks
     Loaded: loaded (/usr/lib/systemd/system/flatpak-preinstalld.service; enabled; preset: enabled)
     Active: active (exited) since Sat 2026-08-15 16:33:29 JST; 12s ago
 Invocation: c0c4a63b4b9c4c22bfd83ebe46015aff
       Docs: man:flatpak-preinstall(1)
    Process: 4439 ExecStart=mkdir -p /var/lib/flatpak/ (code=exited, status=0/SUCCESS)
    Process: 4440 ExecStart=/usr/bin/flatpak preinstall -y (code=exited, status=0/SUCCESS)
    Process: 4504 ExecStart=touch /var/lib/flatpak/.preinstall-finished (code=exited, status=0/SUCCESS)
   Main PID: 4504 (code=exited, status=0/SUCCESS)
   Mem peak: 523M
        CPU: 3.800s

Aug 15 16:33:26 elementary-9-daily flatpak[4440]: Installing… ██████████████████    90%  26.7 MB/s  00:00
Aug 15 16:33:27 elementary-9-daily flatpak[4440]: Installing… ██████████████████▊   94%  27.9 MB/s  00:00
Aug 15 16:33:27 elementary-9-daily flatpak[4440]: Installing… ███████████████████▌  98%  29.3 MB/s  00:00
Aug 15 16:33:27 elementary-9-daily flatpak[4440]: Installing… ████████████████████ 100%  24.7 MB/s  00:00
Aug 15 16:33:28 elementary-9-daily flatpak[4440]: libostree pull from 'flathub' for runtime/org.freedesktop.Platform.GL.defa>
                                                  security: GPG: summary+commit 
                                                  security: SIGN: disabled http: TLS
                                                  delta: parts: 1 loose: 31
                                                  transfer: secs: 6 size: 148.4 MB
Aug 15 16:33:28 elementary-9-daily flatpak[4440]: Installing… ████████████████████ 100%  24.7 MB/s  00:00
Aug 15 16:33:28 elementary-9-daily flatpak[4440]: system: Pulled runtime/org.freedesktop.Platform.GL.default/x86_64/24.08 fr>
Aug 15 16:33:29 elementary-9-daily flatpak[4440]: system: Installed runtime/org.freedesktop.Platform.GL.default/x86_64/24.08>
Aug 15 16:33:29 elementary-9-daily flatpak[4440]: Installation complete.
Aug 15 16:33:29 elementary-9-daily systemd[1]: Finished flatpak-preinstalld.service - Preinstall Flatpaks.
user@elementary-9-daily:~/work/default-settings$ flatpak list --runtime 
Name                      Application ID                           Version      Branch      Origin         Installation
elementary platform       io.elementary.Platform                                8.2         appcenter      system
Mesa                      org.freedesktop.Platform.GL.default      26.1.5       24.08       flathub        system
user@elementary-9-daily:~/work/default-settings$ flatpak run org.gnome.Epiphany 
libEGL warning: failed to get driver name for fd -1

libEGL warning: MESA-LOADER: failed to retrieve device information

libEGL warning: failed to get driver name for fd -1

MESA: error: ZINK: failed to choose pdev
libEGL warning: egl: failed to create dri2 screen
libEGL warning: egl: failed to create dri2 screen
libEGL warning: DRI2: failed to create screen
libEGL warning: egl: failed to create dri2 screen
libEGL warning: DRI2: failed to create screen
user@elementary-9-daily:~/work/default-settings$
```

</details>
